### PR TITLE
예약시간 ISO Format 으로 변경

### DIFF
--- a/example/addScheduledDate.js
+++ b/example/addScheduledDate.js
@@ -1,4 +1,4 @@
-const moment = require('moment-timezone')
+const moment = require('moment')
 const { config, Group } = require('../')
 config.init({
   apiKey: 'ENTER API_KEY',
@@ -15,7 +15,7 @@ async function send (message) {
     const group = new Group()
     await group.createGroup()
     await group.addGroupMessage(message)
-    const scheduledDate = moment().tz('Asia/Seoul').add(1, 'days').format('YYYY-MM-DD H:m:s')
+    const scheduledDate = moment().add(1, 'days').toISOString()
     await group.setScheduledDate(scheduledDate)
   } catch (e) {
     console.log(e)


### PR DESCRIPTION
{ errorCode: 'ValidationError',
  errorMessage: '"body" 유효성 검사 실패 ["scheduledDate" 유효성 검사 실패 ["scheduledDate" must be a valid ISO 8601 date]]' }

유효성 검사에 통과하도록 예약 시간을 ISO Format 으로 입력하도록 수정하였습니다.